### PR TITLE
Fix Typing Issue

### DIFF
--- a/src/app/store/effects/index.ts
+++ b/src/app/store/effects/index.ts
@@ -1,9 +1,9 @@
 import { Action, TypedActionCreator } from '..';
-import { MonoTypeOperatorFunction } from 'rxjs';
+import { OperatorFunction } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 // Custom RXJS Operator
-export function isAction<T extends Action<F>, F>(...actionCreators: TypedActionCreator<F>[]): MonoTypeOperatorFunction<Action<F>> {
+export function isAction<T extends Action<F>, F>(...actionCreators: TypedActionCreator<F>[]): OperatorFunction<any, T> {
     return filter((action: Action<F>): action is T => {
         return actionCreators.some((fn) => fn.type === action.type);
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
+    // "strict": true,
     "strictNullChecks": false,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,


### PR DESCRIPTION
You can do either one of the two changes I made in this PR:

1. In `index.ts` - Instead of returning `MonoTypeOperatorFunction<Action<F>>`, you can return `OperatorFunction<any, T>`
2. In `tsconfig.json`, you can remove `"strict": true`

I would prefer doing option 1 instead

---

This bug makes no sense to me because it says:

```ts
'OperatorFunction<Action<any>, Action<any>>' is not assignable to parameter of type 'OperatorFunction<Action, Action<any>>'
```

But `Action` is a generic type, so you _must_ supply a data type for it. 
I'm not sure why it's expecting an `Action` without a data type.